### PR TITLE
Skip over invalid xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>com.ravn.github</groupId>
     <artifactId>com.microsoft.ews-java-api-2.0</artifactId>
-    <version>001</version>
+    <version>002</version>
 
     <name>${bundle.symbolicName} ${wrapped.version} [github]</name>
     <description>Exchange Web Services (EWS) Java API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,25 @@
         <url>http://www.microsoft.com/</url>
     </organization>
 
+    <developers>
+        <developer>
+            <id>vboctor</id>
+            <name>Victor Boctor</name>
+            <email>vboctor@users.noreply.github.com</email>
+            <url>http://www.github.com/officedev/ews-java-api</url>
+            <organization>Microsoft</organization>
+            <organizationUrl>http://www.microsoft.com</organizationUrl>
+            <roles>
+                <role>administrator</role>
+                <role>developer</role>
+            </roles>
+            <timezone>America/New_York</timezone>
+            <properties>
+                 <picUrl>http://www.example.com/jdoe/pic</picUrl>
+            </properties>
+        </developer>
+    </developers>
+
     <properties>
         <!-- Eliminates the file encoding warning. Of course, all of your files
             should probably be UTF-8 nowadays. -->
@@ -248,6 +267,8 @@
                 <configuration>
                     <!-- Ref.: http://books.sonatype.com/nexus-book/reference/staging-deployment.html -->
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.microsoft.ews-java-api</groupId>
-    <artifactId>ews-java-api</artifactId>
-    
-    <version>2.0</version>
+    <groupId>com.ravn.github</groupId>
+    <artifactId>com.microsoft.ews-java-api-2.0</artifactId>
+    <version>001</version>
 
-    <name>Exchange Web Services Java API</name>
+    <name>${bundle.symbolicName} ${wrapped.version} [github]</name>
     <description>Exchange Web Services (EWS) Java API</description>
 
     <!-- Required by the site command for certain relative URL configuration. -->
@@ -73,6 +72,12 @@
     </developers>
 
     <properties>
+        <!-- RAVN -->
+        <bundle.symbolicName>com.microsoft.ews-java-api</bundle.symbolicName>
+        <wrapped.groupId>com.microsoft.ews-java-api</wrapped.groupId>
+        <wrapped.artifactId>ews-java-api</wrapped.artifactId>
+        <wrapped.version>2.0</wrapped.version>
+
         <!-- Eliminates the file encoding warning. Of course, all of your files
             should probably be UTF-8 nowadays. -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -187,7 +192,7 @@
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.sun.xml.parsers</groupId>
+            <artifactId>jaxp-ri</artifactId>
+            <version>1.4.5</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <groupId>com.microsoft.ews-java-api</groupId>
     <artifactId>ews-java-api</artifactId>
     
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0</version>
 
     <name>Exchange Web Services Java API</name>
     <description>Exchange Web Services (EWS) Java API</description>

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceMultiResponseXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceMultiResponseXmlReader.java
@@ -98,7 +98,7 @@ public class EwsServiceMultiResponseXmlReader extends EwsServiceXmlReader {
    * @throws Exception on error
    */
   @Override
-  protected XMLEventReader initializeXmlReader(InputStream stream)
+  protected XMLEventReader initializeXmlReader(InputStream stream, boolean ignoreErrors)
       throws Exception {
     return createXmlReader(stream);
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
@@ -25,6 +25,7 @@ package microsoft.exchange.webservices.data.core;
 
 import com.sun.org.apache.xerces.internal.impl.Constants;
 import com.sun.org.apache.xerces.internal.impl.XMLErrorReporter;
+import com.sun.xml.internal.stream.XMLInputFactoryImpl;
 import microsoft.exchange.webservices.data.core.enumeration.misc.XmlNamespace;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.misc.OutParam;
@@ -115,7 +116,7 @@ public class EwsXmlReader {
    * @throws Exception on error
    */
   protected XMLEventReader initializeXmlReader(InputStream stream, boolean ignoreErrors) throws Exception {
-    XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+    XMLInputFactory inputFactory = new XMLInputFactoryImpl();
     inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 
     XMLEventReader reader = inputFactory.createXMLEventReader(stream);

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
@@ -125,7 +125,11 @@ public class EwsXmlReader {
       XMLErrorReporter errorReporter =
           (XMLErrorReporter) reader.getProperty(Constants.XERCES_PROPERTY_PREFIX + Constants.ERROR_REPORTER_PROPERTY);
 
-      errorReporter.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.CONTINUE_AFTER_FATAL_ERROR_FEATURE, true);
+      if (errorReporter != null) {
+        errorReporter.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.CONTINUE_AFTER_FATAL_ERROR_FEATURE, true);
+      } else {
+        LOG.warn("Failed to configure ignore errors for the XML Reader. Expected the Xerces parser implementation.");
+      }
     }
 
     return reader;

--- a/src/test/java/microsoft/exchange/webservices/data/core/EwsXmlReaderIgnoreErrorsTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/core/EwsXmlReaderIgnoreErrorsTest.java
@@ -1,0 +1,60 @@
+package microsoft.exchange.webservices.data.core;
+
+import microsoft.exchange.webservices.data.security.XmlNodeType;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.xml.stream.XMLStreamException;
+
+import java.io.ByteArrayInputStream;
+
+public class EwsXmlReaderIgnoreErrorsTest {
+
+  /*
+  From: https://github.com/OfficeDev/ews-java-api/pull/409/commits/e7b7505bc2d8e5432b69d412392387f71fe7bdb5
+   */
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  final String validDocument =  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                                "<test>testContent</test>";
+
+  final String invalidDocument = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                                 "<test>test&#x5;Content</test>";
+
+  @Test
+  public void testReadValidDocument() throws Exception {
+    byte[] bytes = validDocument.getBytes("UTF-8");
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), false);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    String content = impl.readValue();
+    Assert.assertEquals(content, "testContent");
+    impl.read(new XmlNodeType(XmlNodeType.END_DOCUMENT));
+  }
+
+  @Test
+  public void testReadInvalidDocument() throws Exception {
+    byte[] bytes = invalidDocument.getBytes("UTF-8");
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), false);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    exception.expect(XMLStreamException.class);
+    String content = impl.readValue();
+    Assert.assertEquals(content, "test\u0005Content");
+  }
+
+  @Test
+  public void testReadInvalidDocumentWithIgnoreErrors() throws Exception {
+    byte[] bytes = invalidDocument.getBytes("UTF-8");
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), true);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    String content = impl.readValue();
+    Assert.assertEquals(content, "test\u0005Content");
+    impl.read(new XmlNodeType(XmlNodeType.END_DOCUMENT));
+  }
+}


### PR DESCRIPTION
Should fix issues around bad chars in XML.

Also, merged in the forks way of specifying version but changed it to "com.mitimes.*".